### PR TITLE
Add cronjob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .Rhistory
 .RData
 .Ruserdata
+.env
+google

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,8 @@ RUN install2.r --error \
     sicarul/redshiftTools \
   && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
-ADD manual_payments.R manual_payments.R
+
+COPY manual_payments.R /scripts/
+WORKDIR /scripts
+
 CMD ["Rscript", "manual_payments.R"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NAME = julheimer/manual_payments:0.1.0
+NAME = bufferapp/manual-payments:0.1.0
 
 .PHONY: all build run dev
 
@@ -7,8 +7,11 @@ all: run
 build:
 	docker build -t $(NAME) .
 
-run:
+run: build
 	docker run -it --rm $(NAME)
 
+push: build
+	docker push $(NAME)
+
 dev:
-	docker run -v $(PWD):/app -it --rm --env-file ./.env $(NAME)
+	docker run -v $(PWD):/app -it --rm --env-file .env $(NAME)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 	docker build -t $(NAME) .
 
 run: build
-	docker run -it --rm $(NAME)
+	docker run --env-file .env -v $(PWD)/google:/scripts/google -it --rm $(NAME)
 
 push: build
 	docker push $(NAME)

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -1,0 +1,73 @@
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: manual-payments
+spec:
+  schedule: "* * * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 5
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: manual-payments
+            image: bufferapp/manual-payments:0.1.0
+            volumeMounts:
+              - name: googlesheets-token
+                mountPath: /scripts/google
+                readOnly: true
+            env:
+              - name: REDSHIFT_DB_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: redshift
+                    key: database
+              - name: REDSHIFT_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: redshift
+                    key: user
+              - name: REDSHIFT_ENDPOINT
+                valueFrom:
+                  secretKeyRef:
+                    name: redshift
+                    key: endpoint
+              - name: REDSHIFT_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: redshift
+                    key: password
+              - name: REDSHIFT_DB_PORT
+                valueFrom:
+                  secretKeyRef:
+                    name: redshift
+                    key: port
+              - name: AWS_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                      name: aws
+                      key: access-key-id
+              - name: AWS_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                      name: aws
+                      key: secret-access-key
+              - name: AWS_DEFAULT_REGION
+                valueFrom:
+                  secretKeyRef:
+                      name: aws
+                      key: default-region
+            imagePullPolicy: Always
+          restartPolicy: OnFailure
+          imagePullSecrets:
+            - name: dockerhub
+          volumes:
+          - name: googlesheets-token
+            secret:
+              secretName: googlesheets
+              items:
+              - key: token-rds
+                path: googlesheets_token.rds
+

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: manual-payments
 spec:
-  schedule: "* * * * *"
+  schedule: "* * */2 * *"
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 5
   concurrencyPolicy: Forbid

--- a/manual_payments.R
+++ b/manual_payments.R
@@ -21,7 +21,7 @@ read_gs_data <- function() {
   # saveRDS(token, file = "googlesheets_token.rds")
 
   # load oauth token
-  gs_auth(token = "googlesheets_token.rds")
+  gs_auth(token = "./google/googlesheets_token.rds")
 
   # read spreadsheet
   manual <- gs_title("Accounts Receivable - Checks, Invoices, Quotes")


### PR DESCRIPTION
Heya @jwinternheimer! This small PR will make manual payments a cronjob in our Kubernetes cluster. I've made a few small changes I'd love to share:
- I copied the script over a `scripts` folder inside the container
- I've changed the secret `rds` file path to `google/googlesheets_token.rds` inside the R script. If you're running it locally, you'll need to replicate this! :sweat_smile:  
- Changed the image repository to `bufferapp` and added a push command to the Makefile

The script seems to be connecting properly:
```R
Auto-refreshing stale OAuth token.
Sheet successfully identified: "Accounts Receivable - Checks, Invoices, Quotes"
Accessing worksheet titled 'Buffer Invoices'.
```
But it's returning an error when parsing the columns:
```R
Parsed with column specification:
cols(
  .default = col_character()
)
See spec(...) for full column specifications.
Error in mutate_impl(.data, dots) : found duplicated column name: NA
Calls: main ... <Anonymous> -> mutate -> mutate.tbl_df -> mutate_impl -> .Call
```

Once we figure this out, I'll deploy it. I wonder how does once each 2/3 days sounds?
